### PR TITLE
Visitors can increment counter

### DIFF
--- a/count_server/web/channels/counter_channel.ex
+++ b/count_server/web/channels/counter_channel.ex
@@ -1,12 +1,35 @@
+require IEx
+
 defmodule CountServer.CounterChannel do
   use Phoenix.Channel
+  alias CountServer.Counter
+  alias CountServer.Repo
 
   def join("the_counter", _message, socket) do
     {:ok, socket}
   end
 
-  def handle_in("count_up", %{"body" => body}, socket) do
-    broadcast! socket, "count_up", %{body: body}
+  def handle_in("count_up", _params, socket) do
+    counter = Repo.get!(Counter, 1)
+    new_value = counter.main + 1
+
+    changeset = Counter.changeset(counter, %{main: new_value})
+
+
+    # post = MyRepo.get!(Post, 42)
+    # post = Ecto.Changeset.change post, title: "New title"
+    # case MyRepo.update post do
+    #   {:ok, model}        -> # Updated with success
+    #   {:error, changeset} -> # Something went wrong
+    # end
+
+    case Repo.update(changeset) do
+    {:error, changeset} ->
+      broadcast! socket, "count_up", %{body: "EVERYTHING HAS FAILED"}
+    changeset ->
+      broadcast! socket, "count_up", %{body: new_value}
+    end
+
     {:noreply, socket}
   end
 

--- a/count_server/web/channels/user_socket.ex
+++ b/count_server/web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule CountServer.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel "the_counter", CountServer.RoomChannel
+  channel "the_counter", CountServer.CounterChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/count_server/web/controllers/counter_controller.ex
+++ b/count_server/web/controllers/counter_controller.ex
@@ -1,7 +1,8 @@
 defmodule CountServer.CounterController do
   use CountServer.Web, :controller
+  alias CountServer.Counter
 
   def index(conn, _params) do
-    render conn, "index.html"
+    render( conn, "index.html", counter: Repo.get(Counter, 1) )
   end
 end

--- a/count_server/web/static/js/app.js
+++ b/count_server/web/static/js/app.js
@@ -18,4 +18,4 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-// import socket from "./socket"
+import socket from "./socket"

--- a/count_server/web/static/js/socket.js
+++ b/count_server/web/static/js/socket.js
@@ -54,9 +54,26 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+let channel = socket.channel("the_counter", {})
+let counterOutput    = $("#dom-counter")
+let counterIncrement = $("#increment-counter")
+
+//
+counterIncrement.on("click", event => {
+  // counterOutput.html("")
+  channel.push("count_up", {body: "plus_one"})
+})
+
+channel.on("count_up", payload => {
+  if(payload.body === "EVERYTHING HAS FAILED"){
+    counterOutput.append(`<br/>[SHITTT] ${payload.body}`)
+  }else{
+    counterOutput.html(payload.body)
+  }
+})
+
 channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+  .receive("ok", resp => { console.log("Joined successfully get ready to push buttons", resp) })
+  .receive("error", resp => { console.log("Unable to join you are missing out on a world of fun", resp) })
 
 export default socket

--- a/count_server/web/static/js/socket.js
+++ b/count_server/web/static/js/socket.js
@@ -53,27 +53,24 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 
 socket.connect()
 
-// Now that you are connected, you can join channels with a topic:
 let channel = socket.channel("the_counter", {})
 let counterOutput    = $("#dom-counter")
 let counterIncrement = $("#increment-counter")
 
-//
 counterIncrement.on("click", event => {
-  // counterOutput.html("")
   channel.push("count_up", {body: "plus_one"})
 })
 
 channel.on("count_up", payload => {
   if(payload.body === "EVERYTHING HAS FAILED"){
-    counterOutput.append(`<br/>[SHITTT] ${payload.body}`)
+    counterOutput.append(`<br/>[Oh.. oh no...] ${payload.body}`)
   }else{
     counterOutput.html(payload.body)
   }
 })
 
 channel.join()
-  .receive("ok", resp => { console.log("Joined successfully get ready to push buttons", resp) })
+  .receive("ok", resp => { console.log("Joined successfully get ready to increment some counters", resp) })
   .receive("error", resp => { console.log("Unable to join you are missing out on a world of fun", resp) })
 
 export default socket

--- a/count_server/web/templates/counter/index.html.eex
+++ b/count_server/web/templates/counter/index.html.eex
@@ -1,1 +1,4 @@
-ALL WIRED UP!
+<h1>THE COUNTER</h1>
+
+<button type="button" id="increment-counter" name="button">INCREMENT</button>
+<h3 id="dom-counter" value="<%=@counter.main%>"> <%=@counter.main%> </h3>

--- a/count_server/web/templates/layout/app.html.eex
+++ b/count_server/web/templates/layout/app.html.eex
@@ -30,6 +30,7 @@
       </main>
 
     </div> <!-- /container -->
+    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR builds out the browser front-end integration to the app.  Visiting localhost:4000 with a running server displays a counter (stored in the DB) and a button.  Pressing the button then passes a message along the Phoenix counter channel to increment the counter, then broadcasts to all subscribed listeners the value of the new counter and swaps that in on the browser.  With a tab open locally and one in private browsing mode, we can see the counter incrementing when either button is clicked.
